### PR TITLE
Supporting symfony 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,10 +13,10 @@
     ],
     "require": {
         "php": "^7.1.3 || ^8.0",
-        "symfony/config": "^4.4 || ^5.2",
-        "symfony/dependency-injection": "^4.4 || ^5.2",
-        "symfony/event-dispatcher": "^4.4 || ^5.2",
-        "symfony/http-kernel": "^4.4 || ^5.2",
+        "symfony/config": "^4.4 || ^5.2 || ^6.0",
+        "symfony/dependency-injection": "^4.4 || ^5.2 || ^6.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.2 || ^6.0",
+        "symfony/http-kernel": "^4.4 || ^5.2 || ^6.0",
         "gedmo/doctrine-extensions": "^2.3.4 || ^3.0.0"
     },
     "require-dev": {


### PR DESCRIPTION
after try to update to symfony 6 I got this error

```
Root composer.json requires stof/doctrine-extensions-bundle dev-master -> satisfiable by stof/doctrine-extensions-bundle[dev-master].
    - stof/doctrine-extensions-bundle dev-master requires symfony/config ^4.4 || ^5.2 -> found symfony/config[v4.4.0-BETA1, ..., 4.4.x-dev, v5.2.0-BETA1, ..., 5.4.x-dev] but these were not loaded, likely because it conflicts with another require.
```